### PR TITLE
Fix spacenav + joystick launch setup

### DIFF
--- a/launch/teleop.launch.py
+++ b/launch/teleop.launch.py
@@ -10,11 +10,12 @@ def generate_launch_description():
         Node(
             package='spacenav', executable='spacenav_node', name='spacenav_node'
         ),
+        # Teleop for joystick only
         Node(
-            package='turtlebot3_joy_teleop', executable='teleop_node', name='teleop_node',
+            package='turtlebot3_joy_teleop', executable='teleop_node', name='joy_teleop',
             parameters=[
                 {'joy_topic': 'joy'},
-                {'spacenav_topic': 'spacenav/joy'},
+                {'spacenav_topic': ''},
                 {'cmd_vel_topic': 'cmd_vel'},
                 {'use_timestamp': True},
                 {'enable_button': 5},
@@ -22,7 +23,23 @@ def generate_launch_description():
                 {'axis_angular': 0},
                 {'scale_linear': 1.0},
                 {'scale_angular': 1.5},
-                {'require_enable': False}
+                {'require_enable': True}
+            ]
+        ),
+        # Teleop for SpaceNav only
+        Node(
+            package='turtlebot3_joy_teleop', executable='teleop_node', name='spnav_teleop',
+            parameters=[
+                {'joy_topic': ''},
+                {'spacenav_topic': 'spacenav/joy'},
+                {'cmd_vel_topic': 'cmd_vel'},
+                {'use_timestamp': True},
+                {'enable_button': 0},
+                {'axis_linear': 2},
+                {'axis_angular': 4},
+                {'scale_linear': 1.0},
+                {'scale_angular': 1.5},
+                {'require_enable': True}
             ]
         ),
     ])


### PR DESCRIPTION
## Summary
- update launch file to run separate teleop nodes for joystick and SpaceNav
- enable "require_enable" for both nodes
- set specific button and axis mappings for each device

## Testing
- `colcon build --packages-select turtlebot3_joy_teleop` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871a1e234c08332af85e7e13f4bf09d